### PR TITLE
b4s4: Backport EroFS

### DIFF
--- a/BoardConfig-common.mk
+++ b/BoardConfig-common.mk
@@ -73,6 +73,9 @@ TARGET_NO_KERNEL := false
 BOARD_USES_RECOVERY_AS_BOOT := true
 BOARD_USES_METADATA_PARTITION := true
 
+# System Image
+BOARD_SYSTEMIMAGE_FILE_SYSTEM_TYPE := erofs
+
 AB_OTA_UPDATER := true
 
 AB_OTA_PARTITIONS += \
@@ -83,8 +86,8 @@ AB_OTA_PARTITIONS += \
     product \
     system_ext
 
-BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := ext4
-BOARD_SYSTEM_EXTIMAGE_FILE_SYSTEM_TYPE := ext4
+BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := erofs
+BOARD_SYSTEM_EXTIMAGE_FILE_SYSTEM_TYPE := erofs
 
 # Partitions (listed in the file) to be wiped under recovery.
 TARGET_RECOVERY_WIPE := device/google/bonito/recovery.wipe
@@ -110,6 +113,9 @@ BOARD_GOOGLE_DYNAMIC_PARTITIONS_PARTITION_LIST := \
     vendor \
     product \
     system_ext
+
+# Use erofs for vendor image.
+BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := erofs
 
 BOARD_SUPER_PARTITION_SIZE := 4072669184
 BOARD_SUPER_PARTITION_METADATA_DEVICE := system

--- a/BoardConfigLineage.mk
+++ b/BoardConfigLineage.mk
@@ -26,7 +26,7 @@ AB_OTA_PARTITIONS += \
 ifneq ($(PRODUCT_USE_DYNAMIC_PARTITIONS), true)
     BOARD_VENDORIMAGE_PARTITION_SIZE := 805306368
 endif
-BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := ext4
+BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := erofs
 
 # Reserve space for gapps install
 -include vendor/lineage/config/BoardConfigReservedSize.mk

--- a/device-common.mk
+++ b/device-common.mk
@@ -105,7 +105,7 @@ PRODUCT_PACKAGES += \
 AB_OTA_POSTINSTALL_CONFIG += \
     RUN_POSTINSTALL_product=true \
     POSTINSTALL_PATH_product=bin/check_dynamic_partitions \
-    FILESYSTEM_TYPE_product=ext4 \
+    FILESYSTEM_TYPE_product=erofs \
     POSTINSTALL_OPTIONAL_product=false \
 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \

--- a/device.mk
+++ b/device.mk
@@ -151,13 +151,13 @@ PRODUCT_PACKAGES += \
 AB_OTA_POSTINSTALL_CONFIG += \
     RUN_POSTINSTALL_system=true \
     POSTINSTALL_PATH_system=system/bin/otapreopt_script \
-    FILESYSTEM_TYPE_system=ext4 \
+    FILESYSTEM_TYPE_system=erofs \
     POSTINSTALL_OPTIONAL_system=true
 
 AB_OTA_POSTINSTALL_CONFIG += \
     RUN_POSTINSTALL_vendor=true \
     POSTINSTALL_PATH_vendor=bin/checkpoint_gc \
-    FILESYSTEM_TYPE_vendor=ext4 \
+    FILESYSTEM_TYPE_vendor=erofs \
     POSTINSTALL_OPTIONAL_vendor=true
 
 PRODUCT_PACKAGES += \

--- a/fstab.hardware
+++ b/fstab.hardware
@@ -6,9 +6,13 @@
 # Currently we dont have e2fsck compiled. So fs check would failed.
 
 #<src>                                                 <mnt_point>                        <type>  <mnt_flags and options>                            <fs_mgr_flags>
+system                                                  /system                           erofs   ro                                                   wait,slotselect,avb=vbmeta,logical,first_stage_mount
 system                                                  /system                           ext4    ro,barrier=1                                         wait,slotselect,avb=vbmeta,logical,first_stage_mount
+system_ext                                              /system_ext                       erofs   ro                                                   wait,slotselect,avb,logical,first_stage_mount
 system_ext                                              /system_ext                       ext4    ro,barrier=1                                         wait,slotselect,avb,logical,first_stage_mount
+vendor                                                  /vendor                           erofs   ro                                                   wait,slotselect,avb,logical,first_stage_mount
 vendor                                                  /vendor                           ext4    ro,barrier=1                                         wait,slotselect,avb,logical,first_stage_mount
+product                                                 /product                          erofs   ro                                                   wait,slotselect,avb,logical,first_stage_mount
 product                                                 /product                          ext4    ro,barrier=1                                         wait,slotselect,avb,logical,first_stage_mount
 /dev/block/by-name/metadata                             /metadata                         ext4    noatime,nosuid,nodev,discard,data=journal,commit=1   wait,formattable,first_stage_mount
 /dev/block/bootdevice/by-name/userdata                  /data                             f2fs    noatime,nosuid,nodev,discard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier       latemount,wait,check,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,formattable,sysfs_path=/sys/devices/platform/soc/7c4000.sdhci,reservedsize=128M,checkpoint=fs


### PR DESCRIPTION
This is linked to kernel 4.9's commit backporting EroFS.
This implements EroFS for Pixel 3a serie (Bonito/Sargo)